### PR TITLE
Filter with Parent Campaign in JobListing/JobListingFS

### DIFF
--- a/src/classes/VOL_CTRL_JobCalendar.cls
+++ b/src/classes/VOL_CTRL_JobCalendar.cls
@@ -169,8 +169,10 @@ global with sharing class VOL_CTRL_JobCalendar {
 		            listSO.add(new SelectOption(vj.id, vj.name));
 		        }        	
 	        } else {
+                List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignId);
+
 		        for (Volunteer_Job__c vj : [select Name, Id from Volunteer_Job__c 
-		        	where Campaign__c = :campaignId order by name limit 999]) {
+		        	where Campaign__c IN :listCampaignIds order by name limit 999]) {
 		            listSO.add(new SelectOption(vj.id, vj.name));
 		        }
 	        }       
@@ -232,12 +234,13 @@ global with sharing class VOL_CTRL_JobCalendar {
 					and (Volunteer_Job__r.Display_On_Website__c = true or Volunteer_Job__r.Display_On_Website__c = :fWeb)
 				order by Start_Date_Time__c asc];    		
     	} else if (!fAllCampaign && fAllJob) {
+            List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy((Id)strCampaignId);
 			listShifts = [select Id, Name, Volunteer_Job__c, Volunteer_Job__r.Name, Volunteer_Job__r.Volunteer_Website_Time_Zone__c,Volunteer_Job__r.Campaign__r.Volunteer_Website_Time_Zone__c,
 				Volunteer_Job__r.Campaign__c, Start_Date_Time__c, Duration__c,
 				Total_Volunteers__c, Number_of_Volunteers_Still_Needed__c, Description__c
 				from Volunteer_Shift__c
 				where Start_Date_Time__c >= :dtStart and Start_Date_Time__c <= :dtEnd
-					and Volunteer_Job__r.Campaign__c = :strCampaignId
+					and Volunteer_Job__r.Campaign__c IN :listCampaignIds
 					and (Volunteer_Job__r.Display_On_Website__c = true or Volunteer_Job__r.Display_On_Website__c = :fWeb)
 				order by Start_Date_Time__c asc];    		
     	}

--- a/src/classes/VOL_CTRL_JobCalendar.cls
+++ b/src/classes/VOL_CTRL_JobCalendar.cls
@@ -169,10 +169,8 @@ global with sharing class VOL_CTRL_JobCalendar {
 		            listSO.add(new SelectOption(vj.id, vj.name));
 		        }        	
 	        } else {
-                List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignId);
-
 		        for (Volunteer_Job__c vj : [select Name, Id from Volunteer_Job__c 
-		        	where Campaign__c IN :listCampaignIds order by name limit 999]) {
+		        	where Campaign__c = :campaignId order by name limit 999]) {
 		            listSO.add(new SelectOption(vj.id, vj.name));
 		        }
 	        }       
@@ -234,13 +232,12 @@ global with sharing class VOL_CTRL_JobCalendar {
 					and (Volunteer_Job__r.Display_On_Website__c = true or Volunteer_Job__r.Display_On_Website__c = :fWeb)
 				order by Start_Date_Time__c asc];    		
     	} else if (!fAllCampaign && fAllJob) {
-            List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy((Id)strCampaignId);
 			listShifts = [select Id, Name, Volunteer_Job__c, Volunteer_Job__r.Name, Volunteer_Job__r.Volunteer_Website_Time_Zone__c,Volunteer_Job__r.Campaign__r.Volunteer_Website_Time_Zone__c,
 				Volunteer_Job__r.Campaign__c, Start_Date_Time__c, Duration__c,
 				Total_Volunteers__c, Number_of_Volunteers_Still_Needed__c, Description__c
 				from Volunteer_Shift__c
 				where Start_Date_Time__c >= :dtStart and Start_Date_Time__c <= :dtEnd
-					and Volunteer_Job__r.Campaign__c IN :listCampaignIds
+					and Volunteer_Job__r.Campaign__c = :strCampaignId
 					and (Volunteer_Job__r.Display_On_Website__c = true or Volunteer_Job__r.Display_On_Website__c = :fWeb)
 				order by Start_Date_Time__c asc];    		
     	}

--- a/src/classes/VOL_CTRL_VolunteersJobListing.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListing.cls
@@ -105,6 +105,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
                 DateTime dtNow = system.Now().addHours(-1);
                 
                 if (campaignIdFilter != null) {
+                    List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, 
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
@@ -112,7 +113,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
                             Description__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow 
                             order by Start_Date_Time__c) 
-                        from Volunteer_Job__c where Campaign__c = :campaignIdFilter and Display_on_Website__c = true 
+                        from Volunteer_Job__c where Campaign__c IN :listCampaignIds and Display_on_Website__c = true 
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else {
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, 

--- a/src/classes/VOL_CTRL_VolunteersJobListing.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListing.cls
@@ -11,6 +11,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
     global boolean ShowLocationInfo { get; set; }
     global boolean ShowSkills { get; set; }
     global boolean ShowShifts { get; set; }
+    global boolean ShowCampaignHierarchy {get;set;}
     
     
     // dummy contact record to bind the Contact SignUp form to.
@@ -73,6 +74,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
         ShowLocationInfo = true;
         ShowSkills = false;
         ShowShifts = true;
+        ShowCampaignHierarchy = true;
         
         // handle optional parameters (must use string, not ID, to handle null)
         map<string, string> params = ApexPages.currentPage().getParameters();
@@ -90,6 +92,8 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
         if (p != null && p == '1') ShowSkills = true;
         p = params.get('ShowShifts');
         if (p != null && p == '0') ShowShifts = false;
+        p = params.get('ShowCampaignHierarchy');
+        if (p != null && p == '0') ShowCampaignHierarchy = false;
         
         vhTemp.Number_of_Volunteers__c = 1;
         contactIdSignUp = null;
@@ -105,7 +109,10 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
                 DateTime dtNow = system.Now().addHours(-1);
                 
                 if (campaignIdFilter != null) {
-                    List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);
+                    List<Id> listCampaignIds = new List<Id> {campaignIdFilter};
+                    if (ShowCampaignHierarchy) {
+                        listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);    
+                    }
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, 
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,

--- a/src/classes/VOL_CTRL_VolunteersJobListing.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListing.cls
@@ -74,7 +74,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
         ShowLocationInfo = true;
         ShowSkills = false;
         ShowShifts = true;
-        ShowCampaignHierarchy = true;
+        ShowCampaignHierarchy = false;
         
         // handle optional parameters (must use string, not ID, to handle null)
         map<string, string> params = ApexPages.currentPage().getParameters();
@@ -93,7 +93,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListing {
         p = params.get('ShowShifts');
         if (p != null && p == '0') ShowShifts = false;
         p = params.get('ShowCampaignHierarchy');
-        if (p != null && p == '0') ShowCampaignHierarchy = false;
+        if (p != null && p == '1') ShowCampaignHierarchy = true;
         
         vhTemp.Number_of_Volunteers__c = 1;
         contactIdSignUp = null;

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -213,6 +213,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         from Volunteer_Job__c where Id = :jobIdFilter  
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else if (campaignIdFilter != null) {
+                    List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, Campaign__r.Volunteer_Website_Time_Zone__c, 
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
@@ -220,7 +221,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                             Description__c, System_Note__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
                             order by Start_Date_Time__c) 
-                        from Volunteer_Job__c where Campaign__c = :campaignIdFilter and Display_on_Website__c = true 
+                        from Volunteer_Job__c where Campaign__c IN :listCampaignIds and Display_on_Website__c = true 
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else {
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, Campaign__r.Volunteer_Website_Time_Zone__c,

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -107,7 +107,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
         ShowLocationInfo = true;
         ShowSkills = false;
         ShowShifts = true;
-        ShowCampaignHierarchy = true;
+        ShowCampaignHierarchy = false;
         strLanguage = 'en-us'; 
         strDateFormat = 'EEEE M/d/yyyy';
         strTimeFormat = 'h:mm tt';
@@ -139,7 +139,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
         p = params.get('ShowShifts');
         if ( p == '0') ShowShifts = false;
         p = params.get('ShowCampaignHierarchy');
-        if ( p == '0') ShowCampaignHierarchy = false;
+        if ( p == '1') ShowCampaignHierarchy = true;
         p = params.get('Language');
         if (p != null && p != '') strLanguage = p;
         p = params.get('DateFormat');

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -16,6 +16,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
     global boolean ShowLocationInfo { get; set; }
     global boolean ShowSkills { get; set; }
     global boolean ShowShifts { get; set; }
+    global boolean ShowCampaignHierarchy { get; set; }
     global string strLanguage { get; set; }
     global string strDateFormat { get; set; }
     global string strTimeFormat { get; set; }
@@ -106,6 +107,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
         ShowLocationInfo = true;
         ShowSkills = false;
         ShowShifts = true;
+        ShowCampaignHierarchy = true;
         strLanguage = 'en-us'; 
         strDateFormat = 'EEEE M/d/yyyy';
         strTimeFormat = 'h:mm tt';
@@ -136,6 +138,8 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
         if (p == '1') ShowSkills = true;
         p = params.get('ShowShifts');
         if ( p == '0') ShowShifts = false;
+        p = params.get('ShowCampaignHierarchy');
+        if ( p == '0') ShowCampaignHierarchy = false;
         p = params.get('Language');
         if (p != null && p != '') strLanguage = p;
         p = params.get('DateFormat');
@@ -213,7 +217,10 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         from Volunteer_Job__c where Id = :jobIdFilter  
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else if (campaignIdFilter != null) {
-                    List<Id> listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);
+                    List<Id> listCampaignIds = new List<Id> {campaignIdFilter};
+                    if (ShowCampaignHierarchy) {
+                        listCampaignIds = VOL_SharedCode.listIdsCampaignsInHierarchy(campaignIdFilter);    
+                    }
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, Campaign__r.Volunteer_Website_Time_Zone__c, 
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,

--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -629,6 +629,29 @@ global with sharing class VOL_SharedCode {
 		        } 
 		    }
 	}
+    // This massively nested SOQL where statement looks hard coded and dumb, but as it turns out
+    // there's a limit on number of campaign hierarchy levels anyway, so this isn't as dumb as it 
+    // seems. This method will get all campaigns in hierarchy, and keeps the logic in a single query
+
+    /*******************************************************************************************************
+    * @description Static method that takes an Id
+    * Return a list of Campaign Ids that are children/grand-children &c of the given Campaign.
+    * @param Id for any campaign 
+    * @return List<Id> of child campaigns
+    ********************************************************************************************************/
+
+    global static List<Id> listIdsCampaignsInHierarchy(Id campaignId) {
+        Map<Id,Campaign> campaignsInHierarchy = new Map<Id,Campaign>(
+            [SELECT Id,Name FROM Campaign WHERE IsActive =:true AND 
+            (Id =: campaignId
+             OR ParentId =: campaignId
+             OR Parent.ParentId =: campaignId
+             OR Parent.Parent.ParentId =: campaignId
+             OR Parent.Parent.Parent.ParentId =: campaignId
+             OR Parent.Parent.Parent.Parent.ParentId =: campaignId)]
+        );
+        return new List<Id>(campaignsInHierarchy.keySet());
+    }
 
      
 }

--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -642,7 +642,8 @@ global with sharing class VOL_SharedCode {
 
     global static List<Id> listIdsCampaignsInHierarchy(Id campaignId) {
         Map<Id,Campaign> campaignsInHierarchy = new Map<Id,Campaign>(
-            [SELECT Id,Name FROM Campaign WHERE IsActive =:true AND 
+            [SELECT Id,Name FROM Campaign WHERE IsActive =:true  
+             AND RecordTypeId =: recordtypeIdVolunteersCampaign AND
             (Id =: campaignId
              OR ParentId =: campaignId
              OR Parent.ParentId =: campaignId

--- a/src/classes/VOL_SharedCode_TEST.cls
+++ b/src/classes/VOL_SharedCode_TEST.cls
@@ -99,11 +99,6 @@ public with sharing class VOL_SharedCode_TEST {
 			system.assertEquals(1, listCon2.size());
 		}
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 263044f... VOL_SharedCode.listIdsCampaignsInHierarchy will return a list of all child, grandchild, &c campaigns from a given campaign Id.
     /*
     * └── grandparent
     *     ├── parent1
@@ -153,15 +148,9 @@ public with sharing class VOL_SharedCode_TEST {
         System.assert(child5Set.contains(grandchild3.Id));
         System.assert(!child5Set.contains(parent2.Id));
 
-<<<<<<< HEAD
         // check that it won't screw up w/ no children
         System.assertEquals(1, VOL_SharedCode.listIdsCampaignsInHierarchy(grandchild3.Id).size());
 
     }
->>>>>>> 15030a2... last assert for more comprehensive testing
-=======
-    }
->>>>>>> 263044f... VOL_SharedCode.listIdsCampaignsInHierarchy will return a list of all child, grandchild, &c campaigns from a given campaign Id.
-
 
 }

--- a/src/classes/VOL_SharedCode_TEST.cls
+++ b/src/classes/VOL_SharedCode_TEST.cls
@@ -99,6 +99,62 @@ public with sharing class VOL_SharedCode_TEST {
 			system.assertEquals(1, listCon2.size());
 		}
     }
+<<<<<<< HEAD
+=======
+    /*
+    * └── grandparent
+    *     ├── parent1
+    *     │   ├── child1
+    *     │   ├── child2
+    *     │   └── child3
+    *     └── parent2
+    *         ├── child4
+    *         └── child5
+    *             ├── grandchild1
+    *             ├── grandchild2
+    *             └── grandchild3
+* 
+    */
+    static testmethod void testCampaignHierarchy() {
+        // build campaign hierarchy as shown above
+        Campaign grandParent = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, name='Grandparent', IsActive=true);
+        insert grandParent;
+        Campaign parent1 = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = grandParent.Id, name='Parent 1 of 2', IsActive=true);
+        Campaign parent2 = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = grandParent.Id, name='Parent 2 of 2', IsActive=true);
+        insert new List<Campaign> {parent1, parent2};
+        Campaign child1 = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = parent1.Id, name='Child 1 of 5', IsActive=true);
+        Campaign child2 = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = parent1.Id, name='Child 2 of 5', IsActive=true);
+        Campaign child3 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = parent1.Id, name='Child 3 of 5', IsActive=true);
+        Campaign child4 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = parent2.Id, name='Child 4 of 5', IsActive=true);
+        Campaign child5 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = parent2.Id, name='Child 5 of 5', IsActive=true);
+        insert new List<Campaign> {child1,child2,child3,child4,child5};
+        Campaign grandchild1 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = child5.Id, name='Grandchild 1 of 3', IsActive=true);
+        Campaign grandchild2 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = child5.Id, name='Grandchild 2 of 3', IsActive=true);
+        Campaign grandchild3 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = child5.Id, name='Grandchild 3 of 3', IsActive=true);
+        insert new List<Campaign> {grandchild1,grandchild2,grandchild3};
+
+        // get a few trees
+        List<Id> parent2Tree = VOL_SharedCode.listIdsCampaignsInHierarchy(parent2.Id);
+        List<Id> parent1Tree = VOL_SharedCode.listIdsCampaignsInHierarchy(parent1.Id);
+        List<Id> grandparentTree = VOL_SharedCode.listIdsCampaignsInHierarchy(grandParent.Id);
+        List<Id> child5Tree = VOL_SharedCode.listIdsCampaignsInHierarchy(child5.Id);
+
+        // check tree sizes
+        System.assertEquals(4,child5Tree.size());
+        System.assertEquals(6, parent2Tree.size());
+        System.assertEquals(4, parent1Tree.size());
+        System.assertEquals(11, grandparentTree.size());
+
+        // check that tree is legit
+        Set<Id> child5Set = new Set<Id>(child5Tree);
+        System.assert(child5Set.contains(grandchild3.Id));
+        System.assert(!child5Set.contains(parent2.Id));
+
+        // check that it won't screw up w/ no children
+        System.assertEquals(1, VOL_SharedCode.listIdsCampaignsInHierarchy(grandchild3.Id).size());
+
+    }
+>>>>>>> 15030a2... last assert for more comprehensive testing
 
 
 }

--- a/src/classes/VOL_SharedCode_TEST.cls
+++ b/src/classes/VOL_SharedCode_TEST.cls
@@ -100,7 +100,10 @@ public with sharing class VOL_SharedCode_TEST {
 		}
     }
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> 263044f... VOL_SharedCode.listIdsCampaignsInHierarchy will return a list of all child, grandchild, &c campaigns from a given campaign Id.
     /*
     * └── grandparent
     *     ├── parent1
@@ -150,11 +153,15 @@ public with sharing class VOL_SharedCode_TEST {
         System.assert(child5Set.contains(grandchild3.Id));
         System.assert(!child5Set.contains(parent2.Id));
 
+<<<<<<< HEAD
         // check that it won't screw up w/ no children
         System.assertEquals(1, VOL_SharedCode.listIdsCampaignsInHierarchy(grandchild3.Id).size());
 
     }
 >>>>>>> 15030a2... last assert for more comprehensive testing
+=======
+    }
+>>>>>>> 263044f... VOL_SharedCode.listIdsCampaignsInHierarchy will return a list of all child, grandchild, &c campaigns from a given campaign Id.
 
 
 }


### PR DESCRIPTION
To partially close #141, this adds a ShowCampaignHierarchy boolean query flag, that when set, will show all jobs in all child/grandchild/greatgrandchild/etc... campaigns.