### PR TITLE
Scheduled Job to Mark Past Shifts as 'Complete'

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -7,3 +7,6 @@ src/profiles/Customer Community User.profile
 src/profiles/Partner Community Login User.profile
 src/profiles/Partner Community User.profile
 src/workflows/User.workflow
+config/*
+config/
+*.sublime-*

--- a/src/classes/VOL_AutoCompleter.cls
+++ b/src/classes/VOL_AutoCompleter.cls
@@ -1,14 +1,84 @@
-global class VOL_AutoCompleter implements Schedulable {
+/**
+*
+* @author Christian Carter, @cdcarter
+* @date 10/6/2015
+* @description AutoCompleter finds all Hours records related to Shifts that are in the past, and 
+* marks ones that were 'Confirmed' as 'Completed'. This makes it so the volunteer manager only
+* has to enter no-show volunteers, instead of spend time entering people who show up. It relies
+* on Shift information. It is a schedulable job.
+*
+**/
+
+global class VOL_AutoCompleter implements Database.Batchable<SObject>, Schedulable {
+    /**********************************************************************************************
+    * @description contains the query that will find all Confimed hours records from shifts
+    * in the past.
+    */
+    global static String query = 'SELECT Id,Hours_Worked__c,'+
+            'Volunteer_Shift__r.Duration__c '+
+            'FROM Volunteer_Hours__c '+
+            'WHERE Status__c = \'Confirmed\' '+
+            'AND Shift_Start_Date_Time__c < TODAY '+
+            'AND Do_Not_AutoComplete__c != true';
+
+    /**********************************************************************************************
+    * @description Standard schedulable execute method.  This simply gets the batch started 
+    * when called from a scheduled job.  
+    *
+    * @param sc The system SchedulableContext
+    */    
+
     global void execute(SchedulableContext sc) {
-        List<Volunteer_Hours__c> hoursToProcess = [SELECT Id FROM Volunteer_Hours__c 
-                                                                 WHERE Status__c = 'Confirmed'
-                                                                 AND Shift_Start_Date_Time__c < TODAY
-                                                                 AND Do_Not_AutoComplete__c != true];
-        
+        Database.executeBatch(this,100);
+    }
+    
+    /**********************************************************************************************
+    * @description Standard batch start method.
+    *
+    * @param bc The system BatchableContext 
+    *
+    * @return a QueryLocator for the Hours objects to be updated, as defined 
+    * in VOL_AutoCompleter.query
+    */
+    global Database.QueryLocator start(Database.BatchableContext bc) {
+        return Database.getQueryLocator(VOL_AutoCompleter.query);
+    }
+
+    /**********************************************************************************************
+    * @description The main batch execute method
+    *
+    * @param bc The system BatchableContext
+    * @param listSobj The Volunteer_Hours__c objects to be processed in this batch
+    */
+
+    global void execute(Database.BatchableContext bc, List<Sobject> listSobj) {
+        VOL_AutoCompleter.autoCompleteHours((List<Volunteer_Hours__c>) listSobj);
+    }
+    /**********************************************************************************************
+    * @description An empty batch finish method
+    */
+
+    global void finish(Database.BatchableContext bc) {
+        return;
+    }
+
+    /**********************************************************************************************
+    * @description The meat of the job. It updates the status to Complete (all records passed in 
+    * had a status of 'Confirmed' when run by the classes static query) and sets the Hours Worked
+    * to the duration of the shift, if appropriate
+    * 
+    * @param hoursToProcess the list of Volunteer_Hours__c objects to process in this batch.
+    */
+    
+    global static void autoCompleteHours(List<Volunteer_Hours__c> hoursToProcess) {
         for(Volunteer_Hours__c hr : hoursToProcess) {
+            if(hr.Hours_Worked__c == null) {
+                hr.Hours_Worked__c = hr.Volunteer_Shift__r.Duration__c;
+            } 
             hr.Status__c = 'Completed';
         }
         
         update hoursToProcess;
     }
+
 }

--- a/src/classes/VOL_AutoCompleter.cls
+++ b/src/classes/VOL_AutoCompleter.cls
@@ -1,0 +1,14 @@
+global class VOL_AutoCompleter implements Schedulable {
+    global void execute(SchedulableContext sc) {
+        List<Volunteer_Hours__c> hoursToProcess = [SELECT Id FROM Volunteer_Hours__c 
+                                                                 WHERE Status__c = 'Confirmed'
+                                                                 AND Shift_Start_Date_Time__c < TODAY
+                                                                 AND Do_Not_AutoComplete__c != true];
+        
+        for(Volunteer_Hours__c hr : hoursToProcess) {
+            hr.Status__c = 'Completed';
+        }
+        
+        update hoursToProcess;
+    }
+}

--- a/src/classes/VOL_AutoCompleter.cls
+++ b/src/classes/VOL_AutoCompleter.cls
@@ -19,7 +19,7 @@ global class VOL_AutoCompleter implements Database.Batchable<SObject>, Schedulab
             'FROM Volunteer_Hours__c '+
             'WHERE Status__c = \'Confirmed\' '+
             'AND Shift_Start_Date_Time__c < TODAY '+
-            'AND Volunteer_Job__r.AutoComplete__c = true ' 
+            'AND Volunteer_Job__r.AutoComplete__c = true ' +
             'AND Do_Not_AutoComplete__c != true';
 
     /**********************************************************************************************

--- a/src/classes/VOL_AutoCompleter.cls
+++ b/src/classes/VOL_AutoCompleter.cls
@@ -14,11 +14,12 @@ global class VOL_AutoCompleter implements Database.Batchable<SObject>, Schedulab
     * @description contains the query that will find all Confimed hours records from shifts
     * in the past.
     */
-    global static String query = 'SELECT Id,Hours_Worked__c,'+
+    global static String query = 'SELECT Id,Hours_Worked__c, '+
             'Volunteer_Shift__r.Duration__c '+
             'FROM Volunteer_Hours__c '+
             'WHERE Status__c = \'Confirmed\' '+
             'AND Shift_Start_Date_Time__c < TODAY '+
+            'AND Volunteer_Job__r.AutoComplete__c = true ' 
             'AND Do_Not_AutoComplete__c != true';
 
     /**********************************************************************************************

--- a/src/classes/VOL_AutoCompleter.cls-meta.xml
+++ b/src/classes/VOL_AutoCompleter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/VOL_TEST_AutoCompleter.cls
+++ b/src/classes/VOL_TEST_AutoCompleter.cls
@@ -1,5 +1,5 @@
 @isTest
-public class VOL_TEST_AutoCompleter {
+public class TestAutoCompleter {
     public static String CRON_EXP = '0 0 0 15 3 ? 2022';
  
     @testSetup public static void create_records() {
@@ -8,35 +8,52 @@ public class VOL_TEST_AutoCompleter {
         
         Campaign v = new Campaign(Name='Volunteering', IsActive=true);
         insert v;
+
         Volunteer_Job__c job1 = new Volunteer_Job__c(Name='Work', Campaign__c = v.Id);
         insert job1;
         
-        
         Volunteer_Shift__c pastShift = new Volunteer_Shift__c(Start_Date_Time__c = DateTime.now().addDays(-10), Volunteer_Job__c = job1.Id, Duration__c = 2);
         Volunteer_Shift__c futureShift = new Volunteer_Shift__c(Start_Date_Time__c = DateTime.now().addDays(10), Volunteer_Job__c = job1.Id, Duration__c = 2);
-        insert pastShift;
-        insert futureShift;
+        insert new List<Volunteer_Shift__c> {pastShift, futureShift};
         
         Date pastShiftStartDate = Date.newInstance(pastShift.Start_Date_Time__c.year(), pastShift.Start_Date_Time__c.month(), pastShift.Start_Date_Time__c.day());
         Date futureShiftStartDate = Date.newInstance(futureShift.Start_Date_Time__c.year(), futureShift.Start_Date_Time__c.month(), futureShift.Start_Date_Time__c.day());
         
         List<Volunteer_Hours__c> hoursToInsert = new List<Volunteer_Hours__c>();
+        // this record sets a baseline of 20 completed hours
         hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Start_Date__c = pastShiftStartDate, Volunteer_Job__c = job1.Id, Status__c = 'Completed', Hours_Worked__c  = 20));
-        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = pastShiftStartDate, Volunteer_Shift__c = pastShift.Id, Status__c = 'Confirmed', Hours_Worked__c  = 2));
+
+        // this record tests updates not overriding the Hours Worked
+        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = pastShiftStartDate, Volunteer_Shift__c = pastShift.Id, Status__c = 'Confirmed', Hours_Worked__c  = 3));
+
+        // this record tests the hours sets to duration rule
+        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = pastShiftStartDate, Volunteer_Shift__c = pastShift.Id, Status__c = 'Confirmed'));
         hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = futureShiftStartDate, Volunteer_Shift__c = futureShift.Id, Status__c = 'Confirmed', Hours_Worked__c  = 2));
         insert hoursToInsert;
     }
     
-    @isTest public static void test_autocompletejob() {
+    @isTest public static void test_batch() {
         Contact c = [Select Id, Volunteer_Hours__c FROM Contact LIMIT 1][0];
         System.assertEquals(20, c.Volunteer_Hours__c );
         Test.startTest();
-        String jobId = System.schedule('ScheduleApexClassTest',
-                       CRON_EXP, 
-                       new VOL_AutoCompleter());
-
+        AutoCompleter batchable = new AutoCompleter();
+        Id processId = Database.executeBatch(batchable); 
         Test.stopTest();
         c = [Select Id, Volunteer_Hours__c FROM Contact LIMIT 1][0];
-        System.assertEquals(22, c.Volunteer_Hours__c );
+        System.assertEquals(25, c.Volunteer_Hours__c );
+    }
+    
+    @isTest public static void test_autocompletejob() {
+        Test.startTest();
+        Id jobId = System.schedule('ScheduleApexClassTest',
+                       CRON_EXP, 
+                       new AutoCompleter());
+
+        Test.stopTest();
+        CronTrigger job = [SELECT Id From CronTrigger WHERE Id =: jobId][0];
+        // just asserting that the job exists and we didn't exception.
+        System.assert(job.Id == jobId);
+        // can't assert that the batch actually ran, because stopTest doesn't actually force it to run
+        // see: http://salesforce.stackexchange.com/questions/36806/does-test-stoptest-ensure-a-system-schedule-database-batchable-completes-in-a
     }
 }

--- a/src/classes/VOL_TEST_AutoCompleter.cls
+++ b/src/classes/VOL_TEST_AutoCompleter.cls
@@ -1,0 +1,42 @@
+@isTest
+public class VOL_TEST_AutoCompleter {
+    public static String CRON_EXP = '0 0 0 15 3 ? 2022';
+ 
+    @testSetup public static void create_records() {
+        Contact c = new Contact(FirstName='David',LastName='Habib');
+        insert c;
+        
+        Campaign v = new Campaign(Name='Volunteering', IsActive=true);
+        insert v;
+        Volunteer_Job__c job1 = new Volunteer_Job__c(Name='Work', Campaign__c = v.Id);
+        insert job1;
+        
+        
+        Volunteer_Shift__c pastShift = new Volunteer_Shift__c(Start_Date_Time__c = DateTime.now().addDays(-10), Volunteer_Job__c = job1.Id, Duration__c = 2);
+        Volunteer_Shift__c futureShift = new Volunteer_Shift__c(Start_Date_Time__c = DateTime.now().addDays(10), Volunteer_Job__c = job1.Id, Duration__c = 2);
+        insert pastShift;
+        insert futureShift;
+        
+        Date pastShiftStartDate = Date.newInstance(pastShift.Start_Date_Time__c.year(), pastShift.Start_Date_Time__c.month(), pastShift.Start_Date_Time__c.day());
+        Date futureShiftStartDate = Date.newInstance(futureShift.Start_Date_Time__c.year(), futureShift.Start_Date_Time__c.month(), futureShift.Start_Date_Time__c.day());
+        
+        List<Volunteer_Hours__c> hoursToInsert = new List<Volunteer_Hours__c>();
+        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Start_Date__c = pastShiftStartDate, Volunteer_Job__c = job1.Id, Status__c = 'Completed', Hours_Worked__c  = 20));
+        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = pastShiftStartDate, Volunteer_Shift__c = pastShift.Id, Status__c = 'Confirmed', Hours_Worked__c  = 2));
+        hoursToInsert.add(new Volunteer_Hours__c(Contact__c = c.Id, Volunteer_Job__c = job1.Id, Start_Date__c = futureShiftStartDate, Volunteer_Shift__c = futureShift.Id, Status__c = 'Confirmed', Hours_Worked__c  = 2));
+        insert hoursToInsert;
+    }
+    
+    @isTest public static void test_autocompletejob() {
+        Contact c = [Select Id, Volunteer_Hours__c FROM Contact LIMIT 1][0];
+        System.assertEquals(20, c.Volunteer_Hours__c );
+        Test.startTest();
+        String jobId = System.schedule('ScheduleApexClassTest',
+                       CRON_EXP, 
+                       new VOL_AutoCompleter());
+
+        Test.stopTest();
+        c = [Select Id, Volunteer_Hours__c FROM Contact LIMIT 1][0];
+        System.assertEquals(22, c.Volunteer_Hours__c );
+    }
+}

--- a/src/classes/VOL_TEST_AutoCompleter.cls
+++ b/src/classes/VOL_TEST_AutoCompleter.cls
@@ -9,7 +9,7 @@ public class TestAutoCompleter {
         Campaign v = new Campaign(Name='Volunteering', IsActive=true);
         insert v;
 
-        Volunteer_Job__c job1 = new Volunteer_Job__c(Name='Work', Campaign__c = v.Id);
+        Volunteer_Job__c job1 = new Volunteer_Job__c(Name='Work', Campaign__c = v.Id, AutoComplete__c = true);
         insert job1;
         
         Volunteer_Shift__c pastShift = new Volunteer_Shift__c(Start_Date_Time__c = DateTime.now().addDays(-10), Volunteer_Job__c = job1.Id, Duration__c = 2);

--- a/src/classes/VOL_TEST_AutoCompleter.cls-meta.xml
+++ b/src/classes/VOL_TEST_AutoCompleter.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/objects/Volunteer_Hours__c.object
+++ b/src/objects/Volunteer_Hours__c.object
@@ -635,6 +635,16 @@
         <trackTrending>false</trackTrending>
         <type>Lookup</type>
     </fields>
+    <fields>
+        <fullName>Do_Not_AutoComplete__c</fullName>
+        <defaultValue>false</defaultValue>
+        <description>Used by the Volunteers Auto Completer to indicate that this record should never be completed by the scheduled job. It can be useful to set this flag on historical data.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Should this record be excluded from being automatically marked as complete after the shift has passed?</inlineHelpText>
+        <label>Do Not AutoComplete</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
     <label>Volunteer Hours</label>
     <nameField>
         <displayFormat>{00000}</displayFormat>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -228,6 +228,16 @@
         <trackTrending>false</trackTrending>
         <type>Checkbox</type>
     </fields>
+        <fields>
+        <fullName>AutoComplete__c</fullName>
+        <defaultValue>true</defaultValue>
+        <description>Used by the Volunteers Auto Completer to indicate that this record should be completed by the scheduled job. Opt-in...</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Should this job's hours be autocompleted?</inlineHelpText>
+        <label>Autocomplete?</label>
+        <trackTrending>false</trackTrending>
+        <type>Checkbox</type>
+    </fields>
     <fields>
         <fullName>Skills_Needed__c</fullName>
         <deprecated>false</deprecated>

--- a/src/package.xml
+++ b/src/package.xml
@@ -56,6 +56,8 @@
         <members>VOL_TEST_VolunteerHours_Trigger</members>
         <members>VOL_VRS</members>
         <members>VOL_VRS_TEST</members>
+        <members>VOL_AutoCompleter</members>
+        <members>VOL_TEST_AutoCompleter</members>
         <name>ApexClass</name>
     </types>
     <types>
@@ -149,6 +151,7 @@
         <members>Volunteer_Hours__c.Volunteer_Job__c</members>
         <members>Volunteer_Hours__c.Volunteer_Recurrence_Schedule__c</members>
         <members>Volunteer_Hours__c.Volunteer_Shift__c</members>
+        <members>Volunteer_Hours__c.Do_Not_AutoComplete__c</members>
         <members>Volunteer_Job__c.Campaign__c</members>
         <members>Volunteer_Job__c.Description__c</members>
         <members>Volunteer_Job__c.Display_on_Website__c</members>


### PR DESCRIPTION
Caroline Renard writes to me:
> I now have two clients who have asked for the same thing.  One is a film festival so things are VERY intensive, the other is just busy...  Anyway, they would like to automate the process of recording hours worked by their volunteers - what they are looking for is that the system would just update the Status to "Completed" and the Hours Tracked for any volunteer who is confirmed for a Shift once the shift is over.  (Vol Manager will manually handle the exceptions, like the No Shows.)  

> Updating a Volunteer Hours record seems straightforward enough, but the problem is how to trigger the updates.  It can't be a workflow, I think, because no-one will be editing the record.  But it might be possible to do with a Scheduled Job, I guess, that looks for completed Shifts each night, and runs the updates.  I've not built a Scheduled Job before, but that seemed like a possible solution to me.

So, I built a scheduled job. 

Documentation is located at: https://dl.dropboxusercontent.com/spa/q8pc7mthv83x9i1/volunteers-auto-completer/index.html

I have no clue if this is something you'd want in core, but I thought I'd throw the code your way (as well as my failed attempts to rebase...)